### PR TITLE
修复省略号

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -93,7 +93,7 @@ class DocumentFormatter{
         content = content.replace(/([\u4e00-\u9fa5\u3040-\u30FF。！])\]/g,'$1』');
         content = content.replace(/<([\u4e00-\u9fa5\u3040-\u30FF])/g,'《$1');
         content = content.replace(/([\u4e00-\u9fa5\u3040-\u30FF。！])>/g,'$1》');
-        content = content.replace(/。\{3,}/g,'......');
+        content = content.replace(/。{3,}/g,'\u2026\u2026');
         content = content.replace(/([！？])$1{3,}/g,'$1$1$1');
         content = content.replace(/([。，；：、“”『』〖〗《》])\1{1,}/g,'$1');
         return content;


### PR DESCRIPTION
- 修复匹配规则
- 依据 [Requirements for Chinese Text Layout 中文排版需求](https://www.w3.org/TR/clreq/#table_of_non-bracket_indication_punctuation_marks) 使用 `\u2026`